### PR TITLE
unvendor pybind11 for python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make  # [not win]
+    - git  # [not win]
+    - m2-git # [win]
     - patch  # [not win]
     - m2-patch # [win]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,12 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dm-tree-{{ version }}.tar.gz
   sha256: 30fec8aca5b92823c0e796a2f33b875b4dccd470b57e91e6c542405c5f77fd2a
+  patches:
+    - patches/0003-remove-pybind-fetch.patch
 
 build:
-  number: 0
-  skip: true   #[ppc64le]
+  number: 1
+  skip: true  # [ppc64le or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 
@@ -22,13 +24,14 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make  # [not win]
-    - git  # [not win]
-    - m2-git # [win]
+    - patch  # [not win]
+    - m2-patch # [win]
   host:
     - python
     - pip
     - setuptools
     - wheel
+    - pybind11
   run:
     - python
 

--- a/recipe/patches/0003-remove-pybind-fetch.patch
+++ b/recipe/patches/0003-remove-pybind-fetch.patch
@@ -1,0 +1,40 @@
+diff --git a/tree/CMakeLists.txt b/tree/CMakeLists.txt
+index 8f9946c..d62991e 100644
+--- a/tree/CMakeLists.txt
++++ b/tree/CMakeLists.txt
+@@ -50,19 +50,22 @@ if(APPLE)
+   set (CMAKE_FIND_FRAMEWORK LAST)
+ endif()
+ 
+-# Fetch pybind to be able to use pybind11_add_module symbol.
+-set(PYBIND_VER v2.6.2)
+-include(FetchContent)
+-FetchContent_Declare(
+-  pybind11
+-  GIT_REPOSITORY https://github.com/pybind/pybind11
+-  GIT_TAG        ${PYBIND_VER}
+-)
+-if(NOT pybind11_POPULATED)
+-    FetchContent_Populate(pybind11)
+-    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+-    include_directories(${pybind11_INCLUDE_DIR})
+-endif()
++# Anaconda: Use pybind11 from default instead
++find_package(pybind11 REQUIRED)
++
++# # Fetch pybind to be able to use pybind11_add_module symbol.
++# set(PYBIND_VER v2.6.2)
++# include(FetchContent)
++# FetchContent_Declare(
++#   pybind11
++#   GIT_REPOSITORY https://github.com/pybind/pybind11
++#   GIT_TAG        ${PYBIND_VER}
++# )
++# if(NOT pybind11_POPULATED)
++#     FetchContent_Populate(pybind11)
++#     add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
++#     include_directories(${pybind11_INCLUDE_DIR})
++# endif()
+ 
+ # Needed to disable Abseil tests.
+ set (BUILD_TESTING OFF)


### PR DESCRIPTION
Changes:
- unvendor pybind11 for python 3.11
- increase build number