### PR TITLE
dm-tree 0.1.10 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "dm-tree" %}
-{% set version = "0.1.9" %}
+{% set version = "0.1.10" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: a4c7db3d3935a5a2d5e4b383fc26c6b0cd6f78c6d4605d3e7b518800ecd5342b
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 22f37b599e01cc3402a17f79c257a802aebd8d326de05b54657650845956208a
   patches:
     - patches/0001-allow-cmake-args-from-env.patch
 
 build:
-  number: 3
+  number: 0
   skip: true  # [py<310]
   script_env:                                # [win]
     - CMAKE_GENERATOR=Visual Studio 16 2019  # [win]
@@ -39,7 +39,11 @@ requirements:
     - python
     - absl-py >=0.6.1
     - attrs >=18.2.0
-    - numpy >=1.21
+    - numpy >=1.21.2  # [py>=310]
+    - numpy >=1.23.3  # [py>=311]
+    - numpy >=1.26.0  # [py>=312]
+    - numpy >=2.1.0   # [py>=313]
+    - numpy >=2.3.2   # [py>=314]
     - wrapt >=1.11.2
 
 test:


### PR DESCRIPTION
dm-tree 0.1.10 

**Destination channel:** Defaults

### Links

- [PKG-13346]
- dev_url:        https://github.com/deepmind/tree/tree/0.1.10
- conda_forge:    https://github.com/conda-forge/dm-tree-feedstock
- pypi:           https://pypi.org/project/dm-tree/0.1.10
- pypi inspector: https://inspector.pypi.io/project/dm-tree/0.1.10

### Explanation of changes:

- new version number


[PKG-13346]: https://anaconda.atlassian.net/browse/PKG-13346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ